### PR TITLE
Display  column groups in ember table

### DIFF
--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -75,6 +75,7 @@ StyleBindingsMixin, ResizeHandlerMixin, {
   // through ctrl/cmd-click or shift-click).
   selectionMode: 'single',
 
+  hasColumnGroup: false,
   // ---------------------------------------------------------------------------
   // API - Outputs
   // ---------------------------------------------------------------------------
@@ -192,6 +193,20 @@ StyleBindingsMixin, ResizeHandlerMixin, {
   prepareTableColumns: function() {
     var _this = this;
     var columns = this.get('columns') || Ember.A();
+    if(this.get('hasColumnGroup')) {
+      this.set('columnGroups', columns);
+      columns = columns.reduce(function(result, col) {
+        var innerColumns = col.get('innerColumns');
+        if (innerColumns) {
+          return result.concat(innerColumns);
+        } else {
+          result.push(col);
+          return result;
+        }
+      }, []);
+      this.set('columns', columns);
+    }
+
     columns.setEach('controller', this);
     columns.forEach(function(col, i) {
       col.set('nextResizableColumn', _this.getNextResizableColumn(columns, i));

--- a/addon/models/column-group-definition.js
+++ b/addon/models/column-group-definition.js
@@ -14,7 +14,7 @@ export default ColumnDefinition.extend({
     }, 0);
   }),
 
-  getCellContent: function(row) {
+  getCellContent: function() {
     return "";
   }
 });

--- a/addon/models/column-group-definition.js
+++ b/addon/models/column-group-definition.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+import ColumnDefinition from './column-definition';
+
+export default ColumnDefinition.extend({
+  // ---------------------------------------------------------------------------
+  // API - Inputs
+  // ---------------------------------------------------------------------------
+
+  innerColumns:[],
+
+  savedWidth: Ember.computed(function() {
+    return this.get('innerColumns').reduce(function(res, column) {
+      return res + column.get('savedWidth');
+    }, 0);
+  }),
+
+  getCellContent: function(row) {
+    return "";
+  }
+});

--- a/addon/models/column-group-definition.js
+++ b/addon/models/column-group-definition.js
@@ -9,8 +9,8 @@ export default ColumnDefinition.extend({
   innerColumns:[],
 
   savedWidth: Ember.computed(function() {
-    return this.get('innerColumns').reduce(function(res, column) {
-      return res + column.get('savedWidth');
+    return this.get('innerColumns').getEach('savedWidth').reduce(function(res, width) {
+      return res + width;
     }, 0);
   }),
 

--- a/addon/views/header-cell.js
+++ b/addon/views/header-cell.js
@@ -23,7 +23,10 @@ StyleBindingsMixin, RegisterTableComponentMixin, {
   minWidth: Ember.computed.alias('column.minWidth'),
   maxWidth: Ember.computed.alias('column.maxWidth'),
   nextResizableColumn: Ember.computed.alias('column.nextResizableColumn'),
-  height: Ember.computed.alias('tableComponent._headerHeight'),
+  height: Ember.computed(function(){
+
+    return this.get('column').get('headerCellHeight') || this.get('tableComponent._headerHeight');
+  }),
 
   effectiveMinWidth: Ember.computed(function() {
     if (this.get('tableComponent.columnMode') === 'standard') {

--- a/addon/views/header-group.js
+++ b/addon/views/header-group.js
@@ -6,21 +6,23 @@ export default HeaderBlock.extend({
     return this.get('columnGroup').get('savedWidth');
   }),
 
+  headerHeight: Ember.computed.alias('tableComponent._headerHeight'),
+
   content: Ember.computed(function() {
     var group = this.get('columnGroup');
     if (group.get('innerColumns')) {
       return [[group], group.get('innerColumns')];
     } else {
-      group.set('headerCellHeight', this.get('tableComponent._headerHeight') * 2);
+      group.set('headerCellHeight', this.get('headerHeight') * 2);
       return [[group]];
     }
   }).property('columnGroup'),
 
   createChildView: function(viewClass, attrs) {
     var vc = viewClass.extend({
-      top: attrs.contentIndex * 30,
+      top: attrs.contentIndex * this.get('headerHeight'),
       width: this.get('width'),
-      height: this.get('tableComponent._headerHeight') * 2 / this.get('content').length
+      height: this.get('headerHeight') * 2 / this.get('content').length
     });
     return this._super(vc, attrs);
   }

--- a/addon/views/header-group.js
+++ b/addon/views/header-group.js
@@ -1,0 +1,27 @@
+import Ember from 'ember';
+import HeaderBlock from '../views/header-block';
+
+export default HeaderBlock.extend({
+  width: Ember.computed(function() {
+    return this.get('columnGroup').get('savedWidth');
+  }),
+
+  content: Ember.computed(function() {
+    var group = this.get('columnGroup');
+    if (group.get('innerColumns')) {
+      return [[group], group.get('innerColumns')];
+    } else {
+      group.set('headerCellHeight', this.get('tableComponent._headerHeight') * 2);
+      return [[group]];
+    }
+  }).property('columnGroup'),
+
+  createChildView: function(viewClass, attrs) {
+    var vc = viewClass.extend({
+      top: attrs.contentIndex * 30,
+      width: this.get('width'),
+      height: this.get('tableComponent._headerHeight') * 2 / this.get('content').length
+    });
+    return this._super(vc, attrs);
+  }
+});

--- a/addon/views/header-row.js
+++ b/addon/views/header-row.js
@@ -15,7 +15,7 @@ StyleBindingsMixin, RegisterTableComponentMixin, {
 
   rowWidth: Ember.computed(function() {
     var hasColumnGroup = this.get('tableComponent.hasGroupColumn');
-    return this.get(hasColumnGroup ? 'width' : 'controller._tableColumnsWidth')
+    return this.get(hasColumnGroup ? 'width' : 'controller._tableColumnsWidth');
   }),
   // Options for jQuery UI sortable
   sortableOption: Ember.computed(function() {

--- a/addon/views/header-row.js
+++ b/addon/views/header-row.js
@@ -8,11 +8,15 @@ export default Ember.View.extend(
 StyleBindingsMixin, RegisterTableComponentMixin, {
   templateName: 'header-row',
   classNames: ['ember-table-table-row', 'ember-table-header-row'],
-  styleBindings: ['width'],
+  styleBindings: ['width', 'top', 'height'],
   columns: Ember.computed.alias('content'),
   width: Ember.computed.alias('tableComponent._rowWidth'),
   scrollLeft: Ember.computed.alias('tableComponent._tableScrollLeft'),
 
+  rowWidth: Ember.computed(function() {
+    var hasColumnGroup = this.get('tableComponent.hasGroupColumn');
+    return this.get(hasColumnGroup ? 'width' : 'controller._tableColumnsWidth')
+  }),
   // Options for jQuery UI sortable
   sortableOption: Ember.computed(function() {
     return {

--- a/addon/views/header-table-container.js
+++ b/addon/views/header-table-container.js
@@ -20,6 +20,6 @@ ShowHorizontalScrollMixin, RegisterTableComponentMixin, {
 
   width: Ember.computed.alias('tableComponent._tableContainerWidth'),
   hasColumnGroup: Ember.computed(function() {
-    return this.get('tableComponent.hasColumnGroup')
+    return this.get('tableComponent.hasColumnGroup');
   })
 });

--- a/addon/views/header-table-container.js
+++ b/addon/views/header-table-container.js
@@ -9,6 +9,17 @@ ShowHorizontalScrollMixin, RegisterTableComponentMixin, {
   classNames: ['ember-table-table-container',
       'ember-table-fixed-table-container',
       'ember-table-header-container'],
-  height: Ember.computed.alias('tableComponent._headerHeight'),
-  width: Ember.computed.alias('tableComponent._tableContainerWidth')
+  height: Ember.computed(function() {
+    var oldHeight = this.get('tableComponent._headerHeight');
+    if (this.get('hasColumnGroup')) {
+      return oldHeight * 2;
+    } else {
+      return oldHeight;
+    }
+  }).property('tableComponent._headerHeight'),
+
+  width: Ember.computed.alias('tableComponent._tableContainerWidth'),
+  hasColumnGroup: Ember.computed(function() {
+    return this.get('tableComponent.hasColumnGroup')
+  })
 });

--- a/app/templates/header-row.hbs
+++ b/app/templates/header-row.hbs
@@ -1,5 +1,5 @@
 {{view "multi-item-collection"
   contentBinding="view.content"
   itemViewClassField="headerCellViewClass"
-  widthBinding="controller._tableColumnsWidth"
+  widthBinding="rowWidth"
 }}

--- a/app/templates/header-table-container.hbs
+++ b/app/templates/header-table-container.hbs
@@ -6,10 +6,20 @@
       height=headerHeight
     }}
   {{/if}}
-  {{view "header-block" classNames="ember-table-right-table-block"
+  {{#if hasColumnGroup}}
+    {{#each group in columnGroups}}
+      {{view "header-group" classNames="ember-table-right-table-block"
+      columnGroup=group
+      scrollLeft=_tableScrollLeft
+      height=headerHeight
+      }}
+    {{/each}}
+  {{else}}
+    {{view "header-block" classNames="ember-table-right-table-block"
     columns=tableColumns
     scrollLeft=_tableScrollLeft
     width=_tableBlockWidth
     height=headerHeight
-  }}
+    }}
+  {{/if}}
 </div>

--- a/app/views/header-group.js
+++ b/app/views/header-group.js
@@ -1,0 +1,3 @@
+import HeaderGroup from 'ember-table/views/header-group';
+
+export default HeaderGroup;

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli/ember-cli-test-loader#0.1.1",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
-    "ember-qunit": "0.2.8",
+    "ember-qunit": "0.4.0",
     "ember-qunit-notifications": "0.0.7",
     "lodash": "^2.4.0",
     "qunit": "~1.17.1"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-static-compiler": "^0.2.1",
     "broccoli-writer": "^0.1.1",
-    "ember-cli": "0.2.0",
+    "ember-cli": "0.2.5",
     "ember-cli-6to5": "^3.0.0",
     "ember-cli-app-version": "0.3.1",
     "ember-cli-content-security-policy": "0.4.0",

--- a/tests/unit/components/ember-table-test.js
+++ b/tests/unit/components/ember-table-test.js
@@ -1,0 +1,93 @@
+import {
+  moduleForComponent,
+  test
+  } from 'ember-qunit';
+
+import ColumnDefinition from 'ember-table/models/column-definition';
+import ColumnGroupDefinition from 'ember-table/models/column-group-definition';
+
+var columns, table;
+
+moduleForComponent('ember-table', 'EmberTableComponent', {
+
+  beforeEach: function () {
+
+    var firstColumn, secondColumn, thirdColumn, firstGroup;
+
+    firstColumn = ColumnDefinition.create({
+      textAlign: 'text-align-left',
+      headerCellName: 'Column1',
+      getCellContent: function (row) {
+        return row.get('a');
+      }
+    });
+
+    secondColumn = ColumnDefinition.create({
+      textAlign: 'text-align-left',
+      headerCellName: 'Column2',
+      getCellContent: function (row) {
+        return row.get('b');
+      }
+    });
+
+    thirdColumn = ColumnDefinition.create({
+      textAlign: 'text-align-left',
+      headerCellName: 'Column3',
+      getCellContent: function (row) {
+        return row.get('c');
+      }
+    });
+
+    firstGroup = ColumnGroupDefinition.create({
+      headerCellName: 'Group1',
+      innerColumns: [secondColumn, thirdColumn]
+    });
+
+    columns = [firstColumn, firstGroup];
+
+  },
+
+  needs: [
+    'view:body-table-container',
+    'view:column-sortable-indicator',
+    'view:footer-table-container',
+    'view:header-cell',
+    'view:header-row',
+    'view:header-table-container',
+    'view:scroll-container',
+    'view:lazy-table-block',
+    'view:multi-item-collection',
+    'view:scroll-container',
+    'view:scroll-panel',
+    'view:table-block',
+    'view:table-cell',
+    'view:table-row',
+    'view:header-group',
+    'template:body-table-container',
+    'template:footer-table-container',
+    'template:header-cell',
+    'template:header-row',
+    'template:header-table-container',
+    'template:scroll-container',
+    'template:table-cell',
+    'template:table-row'
+  ]
+});
+
+test('it renders', function (assert) {
+
+  this.subject({
+    columns: columns,
+    hasFooter: false,
+    enableContentSelection: true,
+    hasColumnGroup: true
+  });
+
+  assert.equal(this.$('.ember-table-header-block').length, 2);
+
+  assert.equal(this.$('span:contains(Column1)').length, 1);
+  assert.equal(this.$('span:contains(Column2)').length, 1);
+  assert.equal(this.$('span:contains(Column3)').length, 1);
+  assert.equal(this.$('span:contains(Group1)').length, 1);
+
+});

--- a/tests/unit/components/ember-table-test.js
+++ b/tests/unit/components/ember-table-test.js
@@ -6,13 +6,11 @@ import {
 import ColumnDefinition from 'ember-table/models/column-definition';
 import ColumnGroupDefinition from 'ember-table/models/column-group-definition';
 
-var columns, table;
+var columns, firstColumn, secondColumn, thirdColumn, firstGroup;
 
 moduleForComponent('ember-table', 'EmberTableComponent', {
 
   beforeEach: function () {
-
-    var firstColumn, secondColumn, thirdColumn, firstGroup;
 
     firstColumn = ColumnDefinition.create({
       textAlign: 'text-align-left',
@@ -43,8 +41,6 @@ moduleForComponent('ember-table', 'EmberTableComponent', {
       innerColumns: [secondColumn, thirdColumn]
     });
 
-    columns = [firstColumn, firstGroup];
-
   },
 
   needs: [
@@ -53,6 +49,7 @@ moduleForComponent('ember-table', 'EmberTableComponent', {
     'view:footer-table-container',
     'view:header-cell',
     'view:header-row',
+    'view:header-block',
     'view:header-table-container',
     'view:scroll-container',
     'view:lazy-table-block',
@@ -74,20 +71,55 @@ moduleForComponent('ember-table', 'EmberTableComponent', {
   ]
 });
 
-test('it renders', function (assert) {
-
-  this.subject({
-    columns: columns,
+var setEmberTableWithGroup = function(obj) {
+  return obj.subject({
+    columns: [firstColumn, firstGroup],
     hasFooter: false,
-    enableContentSelection: true,
-    hasColumnGroup: true
+    enableContentSelection: true
   });
+};
 
+var setEmberTableWithoutGroup = function(obj) {
+  return obj.subject({
+    columns: [firstColumn, secondColumn, thirdColumn],
+    hasFooter: false,
+    enableContentSelection: true
+  });
+};
+
+// test hasColumnGroup
+
+test('it should has column group', function (assert) {
+  var component = setEmberTableWithGroup(this);
+
+  assert.ok(component.get('hasColumnGroup'));
+});
+
+test('it should not has column group', function (assert) {
+  var component = setEmberTableWithoutGroup(this);
+
+  assert.ok(!component.get('hasColumnGroup'));
+});
+
+// test template
+
+var validateColumnNames = function(assert, obj) {
+  assert.equal(obj.$('span:contains(Column1)').length, 1);
+  assert.equal(obj.$('span:contains(Column2)').length, 1);
+  assert.equal(obj.$('span:contains(Column3)').length, 1);
+};
+
+test('it should render all columns in two blocks', function (assert) {
+  setEmberTableWithGroup(this);
+
+  validateColumnNames(assert, this);
   assert.equal(this.$('.ember-table-header-block').length, 2);
-
-  assert.equal(this.$('span:contains(Column1)').length, 1);
-  assert.equal(this.$('span:contains(Column2)').length, 1);
-  assert.equal(this.$('span:contains(Column3)').length, 1);
   assert.equal(this.$('span:contains(Group1)').length, 1);
+});
 
+test('it should render all columns in one block', function (assert) {
+  setEmberTableWithoutGroup(this);
+
+  validateColumnNames(assert, this);
+  assert.equal(this.$('.ember-table-header-block').length, 1);
 });


### PR DESCRIPTION
Column groups only can be displayed in ember table. Now, they **can't be resized or reordered**.