### PR TITLE
no flashing on resizing.

### DIFF
--- a/addon/styles/addon.less
+++ b/addon/styles/addon.less
@@ -195,6 +195,8 @@
   > div {
     height: 100%;
     .box-sizing();
+    // Column group header should be visible
+    overflow: hidden;
   }
 }
 
@@ -321,6 +323,24 @@
     .ui-resizable-handle {
       background-color: #eaeaea;
     }
+  }
+
+  // Keep last header cell on same line when resizing to right,
+  // otherwise last header cell will flashing while resizing
+  .ember-table-multi-inner-block {
+    .ember-table-header-row {
+      > div {
+        white-space: nowrap!important;
+        text-align: left!important;
+        overflow: hidden;
+
+        .ember-table-header-cell {
+          display: inline-block!important;
+          float: none;
+        }
+      }
+    }
+
   }
 }
 

--- a/addon/styles/addon.less
+++ b/addon/styles/addon.less
@@ -330,11 +330,12 @@
   .ember-table-multi-inner-block {
     .ember-table-header-row {
       > div {
-        white-space: nowrap!important;
-        text-align: left!important;
+        white-space: nowrap;
+        text-align: left;
         overflow: hidden;
 
         .ember-table-header-cell {
+          //use important as .ember-table-header-cell has already used important for display
           display: inline-block!important;
           float: none;
         }

--- a/addon/views/header-group.js
+++ b/addon/views/header-group.js
@@ -3,7 +3,7 @@ import HeaderBlock from '../views/header-block';
 
 export default HeaderBlock.extend({
 
-  classNameBindings: [ 'columnGroup.groupStyle' ],
+  classNameBindings: [ 'columnGroup.groupStyle', 'hasMultiInnerColumns:ember-table-multi-inner-block' ],
 
   width: Ember.computed.alias('columnGroup.savedWidth'),
 
@@ -18,6 +18,11 @@ export default HeaderBlock.extend({
       return [[group]];
     }
   }).property('columnGroup'),
+
+  hasMultiInnerColumns: Ember.computed(function() {
+    var innerColumns = this.get('columnGroup.innerColumns');
+    return innerColumns && innerColumns.length > 1;
+  }).property("columnGroup.innerColumns.[]"),
 
   createChildView: function(viewClass, attrs) {
     var vc = viewClass.extend({

--- a/addon/views/header-row.js
+++ b/addon/views/header-row.js
@@ -8,7 +8,7 @@ export default Ember.View.extend(
 StyleBindingsMixin, RegisterTableComponentMixin, {
   templateName: 'header-row',
   classNames: ['ember-table-table-row', 'ember-table-header-row'],
-  styleBindings: ['width', 'top', 'height'],
+  styleBindings: ['top', 'height'],
   columns: Ember.computed.alias('content'),
   width: Ember.computed.alias('tableComponent._rowWidth'),
   scrollLeft: Ember.computed.alias('tableComponent._tableScrollLeft'),


### PR DESCRIPTION
  - last header cell inside a column group will be renderer to a new line when its width is larger then the width of its outer container.
  - the css rules added is to keep last header cell in the same line when a column group contains multiple inner columns