### PR TITLE
add header-groups-block to support scroll left of group header.

### DIFF
--- a/addon/styles/addon.less
+++ b/addon/styles/addon.less
@@ -343,6 +343,10 @@
     }
 
   }
+
+  .ember-table-header-groups-block {
+    height: 100%
+  }
 }
 
 .ember-table-header-container .ember-table-right-table-block .ember-table-table-row {

--- a/addon/views/header-groups-block.js
+++ b/addon/views/header-groups-block.js
@@ -1,0 +1,24 @@
+import Ember from 'ember';
+import StyleBindingsMixin from 'ember-table/mixins/style-bindings';
+import RegisterTableComponentMixin from 'ember-table/mixins/register-table-component';
+
+export default Ember.View.extend(
+StyleBindingsMixin, RegisterTableComponentMixin, {
+    templateName: 'header-groups-block',
+    styleBindings: ['width'],
+    columnGroups: undefined,
+    headerHeight: undefined,
+
+    //table row width will change with each column width so we bind with it
+    width: Ember.computed.alias('tableComponent._rowWidth'),
+
+    //will bind to a property passed in from template, we expect that property reflect scroll position
+    scrollLeft: null,
+    
+    //use JQuery scrollLeft, which needs inner element has a larger width than outter element,
+    //header-groups-block acts as the inner element in scrolling
+    onScrollLeftDidChange: Ember.observer(function() {
+      return this.$().parent().scrollLeft(this.get('scrollLeft'));
+    }, 'scrollLeft')
+
+  });

--- a/app/templates/header-groups-block.hbs
+++ b/app/templates/header-groups-block.hbs
@@ -1,0 +1,7 @@
+{{#each group in columnGroups}}
+  {{view "header-group" classNames="ember-table-right-table-block"
+  columnGroup=group
+  scrollLeft=scrollLeft
+  height=headerHeight
+  }}
+{{/each}}

--- a/app/templates/header-table-container.hbs
+++ b/app/templates/header-table-container.hbs
@@ -7,13 +7,11 @@
     }}
   {{/if}}
   {{#if hasColumnGroup}}
-    {{#each group in columnGroups}}
-      {{view "header-group" classNames="ember-table-right-table-block"
-      columnGroup=group
-      scrollLeft=_tableScrollLeft
-      height=headerHeight
-      }}
-    {{/each}}
+    {{view "header-groups-block" classNames="ember-table-header-groups-block"
+    columnGroups=columnGroups
+    scrollLeft=_tableScrollLeft
+    headerHeight=headerHeight
+    }}
   {{else}}
     {{view "header-block" classNames="ember-table-right-table-block"
     columns=tableColumns

--- a/app/views/header-groups-block.js
+++ b/app/views/header-groups-block.js
@@ -1,0 +1,3 @@
+import HeaderGroupsBlock from 'ember-table/views/header-groups-block';
+
+export default HeaderGroupsBlock;

--- a/tests/unit/components/ember-table-test.js
+++ b/tests/unit/components/ember-table-test.js
@@ -66,6 +66,7 @@ moduleForComponent('ember-table', 'EmberTableComponent', {
     'view:table-cell',
     'view:table-row',
     'view:header-group',
+    'view:header-groups-block',
     'template:body-table-container',
     'template:footer-table-container',
     'template:header-cell',
@@ -73,7 +74,8 @@ moduleForComponent('ember-table', 'EmberTableComponent', {
     'template:header-table-container',
     'template:scroll-container',
     'template:table-cell',
-    'template:table-row'
+    'template:table-row',
+    'template:header-groups-block'
   ]
 });
 
@@ -164,7 +166,7 @@ test('it should set the last column class in group', function(assert) {
 });
 
 function getGroupColumnWidth(table) {
-  return table.$('.ember-table-header-container ' +
+  return table.$('.ember-table-header-container .ember-table-header-groups-block ' +
     '.ember-table-header-block:nth-child(2) ' +
     '.ember-table-header-row:nth-child(1)').width();
 }
@@ -196,7 +198,5 @@ test('Should reorder inner columns when dragging the inner column', function(ass
   });
 
   var col = getInnerColumn(this, 1);
-  console.log(col.text().trim());
-  console.log(firstCol.headerCellName);
   assert.ok(col.text().trim() === firstCol.headerCellName, "Should be header cell name of first column");
 });

--- a/tests/unit/components/partial-data-sort-test.js
+++ b/tests/unit/components/partial-data-sort-test.js
@@ -55,6 +55,7 @@ moduleForComponent('ember-table', 'EmberTableComponent', {
     'view:table-cell',
     'view:table-row',
     'view:header-group',
+    'view:header-groups-block',
     'template:body-table-container',
     'template:footer-table-container',
     'template:header-cell',


### PR DESCRIPTION
  - use jQuery scrollLeft, which needs inner element has a larger width than outter element
  - header-groups-block acts as the inner element in scrolling